### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/content/2013-08-26-how-to-build-a-text-classification-system-with-python-and-textblob.md
+++ b/content/2013-08-26-how-to-build-a-text-classification-system-with-python-and-textblob.md
@@ -262,5 +262,5 @@ TextBlob makes it easy to create your own custom text classifiers. Always rememb
 - [Naive Bayes Classification on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
 - [The NLTK Book, Ch. 6: Learning to Classify Text](http://nltk.googlecode.com/svn/trunk/doc/book/ch06.html)
 
-[TextBlob]: https://textblob.readthedocs.org/en/latest/
-[changelog]: https://textblob.readthedocs.org/en/latest/changelog.html#id1
+[TextBlob]: https://textblob.readthedocs.io/en/latest/
+[changelog]: https://textblob.readthedocs.io/en/latest/changelog.html#id1

--- a/content/2013-09-01-finding-important-words-in-a-document-using-tf-idf.md
+++ b/content/2013-09-01-finding-important-words-in-a-document-using-tf-idf.md
@@ -6,7 +6,7 @@ slug: finding-important-words-in-a-document-using-tf-idf
 *Edit May 25, 2015*: Fix incorrect filter in `n_containing`. Thanks Chen Liang for reporting.
 *Edit October 26, 2014*: Update imports for TextBlob>=0.8.0.
 
- Another [TextBlob][] release (0.6.1, [changelog](https://textblob.readthedocs.org/en/latest/changelog.html)), another quick tutorial. This one's on using the [TF-IDF][] algorithm to find the most important words in a text document. It's simpler than you might think.
+ Another [TextBlob][] release (0.6.1, [changelog](https://textblob.readthedocs.io/en/latest/changelog.html)), another quick tutorial. This one's on using the [TF-IDF][] algorithm to find the most important words in a text document. It's simpler than you might think.
 
 ## What is TF-IDF?
 
@@ -111,5 +111,5 @@ There may be ways to improve the our TF-IDF algorithm, such as by ignoring stopw
 * [Machine Learning with Python: Meeting TF-IDF for Text Mining](http://aimotion.blogspot.com/2011/12/machine-learning-with-python-meeting-tf.html)
 * [Short introduction to Vector Space Model](http://pyevolve.sourceforge.net/wordpress/?p=1589)
 
-[TextBlob]: https://textblob.readthedocs.org/en/latest/
+[TextBlob]: https://textblob.readthedocs.io/en/latest/
 [TF-IDF]: https://en.wikipedia.org/wiki/Tf%E2%80%93idf

--- a/content/2013-09-16-tutorial-state-of-the-art-part-of-speech-tagging-in-textblob.md
+++ b/content/2013-09-16-tutorial-state-of-the-art-part-of-speech-tagging-in-textblob.md
@@ -5,7 +5,7 @@ tags: programming, python, textblob, nlp
 
 *Edit October 26, 2014*: Update imports for TextBlob>=0.8.0.
 
-Following the tradition of writing a short tutorial with each new [TextBlob][] release (0.6.3, [changelog](https://textblob.readthedocs.org/en/latest/changelog.html)), here's an introduction to TextBlob's first outside code contribution from Matthew Honnibal, a.k.a. [syllog1sm](https://github.com/syllog1sm): a part-of-speech tagger based on the [Averaged Perceptron][Perceptron] algorithm which is **faster and more accurate than [NLTK](http://nltk.org/)'s and [pattern](http://www.clips.ua.ac.be/pages/pattern-en)'s default implementations**.
+Following the tradition of writing a short tutorial with each new [TextBlob][] release (0.6.3, [changelog](https://textblob.readthedocs.io/en/latest/changelog.html)), here's an introduction to TextBlob's first outside code contribution from Matthew Honnibal, a.k.a. [syllog1sm](https://github.com/syllog1sm): a part-of-speech tagger based on the [Averaged Perceptron][Perceptron] algorithm which is **faster and more accurate than [NLTK](http://nltk.org/)'s and [pattern](http://www.clips.ua.ac.be/pages/pattern-en)'s default implementations**.
 
 Matthew Honnibal wrote a clear and detailed blog post about the Averaged Perception and his implementation [here][PyAP]. For this reason, this post will focus on how to get and use the tagger without providing implementation details.
 
@@ -20,7 +20,7 @@ $ pip install -U textblob textblob-aptagger
 
 -----
 
-**UPDATE September 19, 2013**: The installation process for the `PerceptronTagger` will be simplified in TextBlob 0.7.0 once the extension system is in place (should be released within the next couple of weeks). If you want to try it out early, [install the dev version of TextBlob](https://textblob.readthedocs.org/en/dev/install.html#get-the-bleeding-edge-version) then install the `textblob-aptagger` extension [here](https://github.com/sloria/textblob-aptagger). Otherwise, TextBlob 0.6.3 users can use the instructions below.
+**UPDATE September 19, 2013**: The installation process for the `PerceptronTagger` will be simplified in TextBlob 0.7.0 once the extension system is in place (should be released within the next couple of weeks). If you want to try it out early, [install the dev version of TextBlob](https://textblob.readthedocs.io/en/dev/install.html#get-the-bleeding-edge-version) then install the `textblob-aptagger` extension [here](https://github.com/sloria/textblob-aptagger). Otherwise, TextBlob 0.6.3 users can use the instructions below.
 
 -----
 <s>
@@ -170,10 +170,10 @@ You can find more extensive evaluations of these three taggers at [Matthew's blo
 
 * [A Good POS Tagger in About 200 Lines of Python - Matthew Honnibal](http://honnibal.wordpress.com/2013/09/11/a-good-part-of-speechpos-tagger-in-about-200-lines-of-python/)
 * [A Course On Machine Learning, Ch. 3. - The Perceptron][Perceptron]
-* [TextBlob Docs - Overriding Models and the Blobber Class](https://textblob.readthedocs.org/en/latest/advanced_usage.html)
+* [TextBlob Docs - Overriding Models and the Blobber Class](https://textblob.readthedocs.io/en/latest/advanced_usage.html)
 
 [^1]: Hosting supplemental models and data on the Releases page is not an ideal solution for the long-term because Github imposes a 5MB limit on file uploads, but it will work for now. If you have a suggestion for a better solution, please join the discussion [here](https://github.com/sloria/TextBlob/issues/20).
 
-[TextBlob]: https://textblob.readthedocs.org/
+[TextBlob]: https://textblob.readthedocs.io/
 [PyAP]: http://honnibal.wordpress.com/2013/09/11/a-good-part-of-speechpos-tagger-in-about-200-lines-of-python/
 [Perceptron]: http://ciml.info/dl/v0_8/ciml-v0_8-ch03.pdf

--- a/content/2013-09-30-tutorial-wordnet-textblob.md
+++ b/content/2013-09-30-tutorial-wordnet-textblob.md
@@ -7,8 +7,8 @@ slug: tutorial-wordnet-textblob
 
 In short, WordNet is a database of English words that are linked together by their semantic relationships. It is like a supercharged dictionary/thesaurus with a graph structure.
 
-[TextBlob](http://textblob.readthedocs.org/) 0.7
-([changelog](http://textblob.readthedocs.org/en/latest/changelog.html)) now integrates NLTK's WordNet interface, making it very simple to interact with WordNet.
+[TextBlob](https://textblob.readthedocs.io/) 0.7
+([changelog](https://textblob.readthedocs.io/en/latest/changelog.html)) now integrates NLTK's WordNet interface, making it very simple to interact with WordNet.
 
 This tutorial is a gentle introduction to WordNet concepts, using TextBlob for the examples. To follow along with the examples, make sure you have the latest version of TextBlob.
 

--- a/content/2013-11-17-mvc-and-apis-keep-em-light-and-fluffy.md
+++ b/content/2013-11-17-mvc-and-apis-keep-em-light-and-fluffy.md
@@ -9,7 +9,7 @@ The MVC design pattern gives us general guidelines on where various components o
 
 But as an application gets larger, it becomes more difficult to decide where certain components belong. Even if we adhere to the "fat models, skinny controllers" advice, we can end up with massive, god-like model classes with many coupled responsibilities.
 
-Here I use the example of data formatting to demonstrate how one might separate responsibilities between classes in a web application and introduce a library called [marshmallow](http://marshmallow.readthedocs.org) which makes the process easier.
+Here I use the example of data formatting to demonstrate how one might separate responsibilities between classes in a web application and introduce a library called [marshmallow](https://marshmallow.readthedocs.io) which makes the process easier.
 
 ## First, let's clear up some terminology.
 
@@ -59,10 +59,10 @@ We should separate these entities so that they can be changed independently of e
 
 The best solution here is to put the serialization logic into a separate class, responsible only for formatting the output data.
 
-You could write these from scratch, though there are a number of libraries that make this easier. One of these is [marshmallow](http://marshmallow.readthedocs.org), written for Python (full disclosure: I'm the author).
+You could write these from scratch, though there are a number of libraries that make this easier. One of these is [marshmallow](https://marshmallow.readthedocs.io), written for Python (full disclosure: I'm the author).
 
-<a href="http://marshmallow.readthedocs.org">
-<img src="http://marshmallow.readthedocs.org/en/latest/_static/marshmallow-logo.png" height="200" alt="marshmallow docs">
+<a href="https://marshmallow.readthedocs.io">
+<img src="https://marshmallow.readthedocs.io/en/latest/_static/marshmallow-logo.png" height="200" alt="marshmallow docs">
 </a>
 
 ## Why marshmallow?
@@ -71,7 +71,7 @@ You could write these from scratch, though there are a number of libraries that 
 - **Reusability.** Schema classes are reusable, are nestable, and allow for inheritance.
 - **Testability.** Schema classes are easier to test than views and controllers.
 - **Agnostic.** ORM, ODM, Flask, Django—doesn't matter. Marshmallow serializes all objects in the same way.
-- **Familiar syntax**. Schemas look very much like [WTForms](https://wtforms.readthedocs.org/en/latest/) or a model definition in any of the popular ORMs.
+- **Familiar syntax**. Schemas look very much like [WTForms](https://wtforms.readthedocs.io/en/latest/) or a model definition in any of the popular ORMs.
 
 ## First steps with marshmallow
 
@@ -130,7 +130,7 @@ schema = TodoSchema()
 schema.dump(todo).data  # Same as above
 ```
 
-Check out marshmallow's documentation—with examples in Flask, SQL-Alchemy, and Peewee—at [http://marshmallow.rtfd.org](http://marshmallow.rtfd.org).
+Check out marshmallow's documentation—with examples in Flask, SQL-Alchemy, and Peewee—at [https://marshmallow.readthedocs.io](https://marshmallow.readthedocs.io).
 
 ## Conclusion
 

--- a/content/2014-04-06-tools-for-productive-python.md
+++ b/content/2014-04-06-tools-for-productive-python.md
@@ -70,7 +70,7 @@ source activate path/to/env/bin/activate
 
 Importing the same packages, modules, and classes every time you run the Python shell is tedious. That's why I created [konch][].
 
-Inspired by [Flask-Script][] and the [shell_plus][] command from [django-extensions](http://django-extensions.readthedocs.org/en/latest/index.html), konch allows you to create project-specific namespaces for your Python shell. You can even configure your shell's [welcome banner and input prompt](http://konch.readthedocs.org/en/latest/#konch-init).
+Inspired by [Flask-Script][] and the [shell_plus][] command from [django-extensions](https://django-extensions.readthedocs.io/en/latest/index.html), konch allows you to create project-specific namespaces for your Python shell. You can even configure your shell's [welcome banner and input prompt](https://konch.readthedocs.io/en/latest/#konch-init).
 
 <img src="https://dl.dropboxusercontent.com/u/1693233/blog/konch-logo.png" width="200" alt="konch logo">
 
@@ -123,9 +123,9 @@ $ echo ".env\n.konchrc" >> ~/.gitignore_global
 
 ## Related Links
 
-- [cookiecutter on Github][cookiecutter] and [docs](http://cookiecutter.readthedocs.org/en/latest/)
+- [cookiecutter on Github][cookiecutter] and [docs](https://cookiecutter.readthedocs.io/en/latest/)
 - [autoenv on Github][autoenv]
-- [konch on Github][konch] and [docs](http://konch.readthedocs.org/en/latest/)
+- [konch on Github][konch] and [docs](https://konch.readthedocs.io/en/latest/)
 
 
 [cookiecutter]: https://github.com/audreyr/cookiecutter
@@ -133,5 +133,5 @@ $ echo ".env\n.konchrc" >> ~/.gitignore_global
 [konch]: https://github.com/sloria/konch
 [yak shaving]: http://projects.csail.mit.edu/gsb/old-archive/gsb-archive/gsb2000-02-11.html
 [Flask-Script]: https://github.com/smurfix/flask-script
-[shell_plus]: http://django-extensions.readthedocs.org/en/latest/shell_plus.html
+[shell_plus]: https://django-extensions.readthedocs.io/en/latest/shell_plus.html
 

--- a/content/2015-09-29-marshmallow-2.md
+++ b/content/2015-09-29-marshmallow-2.md
@@ -15,14 +15,14 @@ Marshmallow is a Python library for
 
 Think Django REST Framework's [Serializers](http://www.django-rest-framework.org/api-guide/serializers/), without the Django.
 
-For more info, see the homepage: [https://marshmallow.readthedocs.org/](https://marshmallow.readthedocs.org/)
+For more info, see the homepage: [https://marshmallow.readthedocs.io/](https://marshmallow.readthedocs.io/)
 
 ## Benefits of Upgrading
 
 Here are a few immediate benefits of upgrading to 2.0:
 
 * Dump-only and load-only fields (analagous to "read-only" and "write-only" in the context of a CRUD app).
-* More consistent treatment of [null](https://marshmallow.readthedocs.org/en/latest/upgrading.html#deserializing-none) and [missing values](https://marshmallow.readthedocs.org/en/latest/upgrading.html#default-values).
+* More consistent treatment of [null](https://marshmallow.readthedocs.io/en/latest/upgrading.html#deserializing-none) and [missing values](https://marshmallow.readthedocs.io/en/latest/upgrading.html#default-values).
 
 * Powerful, user-friendly pre- and post-processing API.
 
@@ -72,7 +72,7 @@ errors = schema.validate(invalid_data)
 
 * Better error bundling when validating multiple objects.
 * Improved ``strict`` mode.
-* Field and [schema validators](https://marshmallow.readthedocs.org/en/latest/extending.html#schema-level-validation) can be written as methods.
+* Field and [schema validators](https://marshmallow.readthedocs.io/en/latest/extending.html#schema-level-validation) can be written as methods.
 
 ## Ecosystem
 
@@ -95,6 +95,6 @@ I will continue to merge bug fixes into the 1.2 release line. No new 1.x feature
 
 ## More
 
- Several refinements were made to the marshmallow API. For details, see the [changelog](https://marshmallow.readthedocs.org/en/latest/changelog.html#changelog). For a guide on upgrading from marshmallow 1, see the [upgrading guide](https://marshmallow.readthedocs.org/en/latest/upgrading.html#upgrading).
+ Several refinements were made to the marshmallow API. For details, see the [changelog](https://marshmallow.readthedocs.io/en/latest/changelog.html#changelog). For a guide on upgrading from marshmallow 1, see the [upgrading guide](https://marshmallow.readthedocs.io/en/latest/upgrading.html#upgrading).
 
  Special thanks to everyone who contributed and reported issues; you made this release awesome.

--- a/content/2015-11-01-releases.md
+++ b/content/2015-11-01-releases.md
@@ -7,32 +7,32 @@ Some notes on some recent releases:
 
 ## TextBlob 0.11.0
 
-[Changelog](https://textblob.readthedocs.org/en/latest/changelog.html)
+[Changelog](https://textblob.readthedocs.io/en/latest/changelog.html)
 
 This mainly fixes compatibility with NLTK 3.1 and above. Older versions of NLTK are no longer supported. As an added bonus, the averaged perceptron tagger described in [this post](http://stevenloria.com/tutorial-state-of-the-art-part-of-speech-tagging-in-textblob/) is now the default part-of-speech tagger in both NLTK and TextBlob.
 
 
 ## marshmallow 2.2.0
 
-[Changelog](https://marshmallow.readthedocs.org/en/latest/changelog.html#changelog)
+[Changelog](https://marshmallow.readthedocs.io/en/latest/changelog.html#changelog)
 
 Adds support for partial deserialization. Also removes pre-2.0 deprecated API.
 
 ## marshmallow-jsonapi 0.3.0
 
-[Changelog](https://marshmallow-jsonapi.readthedocs.org/en/latest/changelog.html#changelog)
+[Changelog](https://marshmallow-jsonapi.readthedocs.io/en/latest/changelog.html#changelog)
 
 Validates JSON API-formatted request payloads. Adds a `Relationship` field for serializing JSON API relationship objects.
 
 ## webargs 1.0.0
 
-[Changelog](https://webargs.readthedocs.org/en/dev/changelog.html#changelog)
+[Changelog](https://webargs.readthedocs.io/en/dev/changelog.html#changelog)
 
 First stable release. Adds support for aiohttp. Also changes the position of injected arguments when using DjangoParser and FalconParser.
 
 
 ## aiohttp_utils 1.0.0
 
-[Changelog](https://aiohttp-utils.readthedocs.org/en/latest/changelog.html#changelog)
+[Changelog](https://aiohttp-utils.readthedocs.io/en/latest/changelog.html#changelog)
 
 New library that includes a number of utilities for building aiohttp applications, including content negotiation, method-based handlers, routing utilities, and development server.

--- a/content/pages/projects.md
+++ b/content/pages/projects.md
@@ -4,9 +4,9 @@ slug: projects
 
 # Recent Projects
 
-**[marshmallow](http://marshmallow.readthedocs.org/)**: A lightweight, ORM-agnostic Python library for serializing objects. Useful for building REST APIs.
+**[marshmallow](https://marshmallow.readthedocs.io/)**: A lightweight, ORM-agnostic Python library for serializing objects. Useful for building REST APIs.
 
-**[TextBlob](http://textblob.readthedocs.org/)**: Simple, Pythonic text processing. Includes part-of-speech tagging, noun phrase parsing, sentiment analysis, and more.
+**[TextBlob](https://textblob.readthedocs.io/)**: Simple, Pythonic text processing. Includes part-of-speech tagging, noun phrase parsing, sentiment analysis, and more.
 
 **[KillTheYak.com][KillTheYak]**: Collection of simple guides for accomplishing programming-related tasks.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.